### PR TITLE
Date serialization issue

### DIFF
--- a/src/main/java/com/alienvault/otx/model/pulse/OtxDateDeserializer.java
+++ b/src/main/java/com/alienvault/otx/model/pulse/OtxDateDeserializer.java
@@ -1,0 +1,40 @@
+package com.alienvault.otx.model.pulse;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/*
+ * © AlienVault Inc. 2017
+ * All rights reserved
+ * This code is protected by copyright and distributed under licenses
+ * restricting its use, copying, distribution, and decompilation. It may
+ * only be reproduced or used under license from AlienVault Inc. or its
+ * authorised licensees.
+ *
+ * Created by crosa on 12/07/2017.
+*/
+public class OtxDateDeserializer extends JsonDeserializer<Date> {
+
+
+    @Override
+    public Date deserialize(JsonParser jsonparser,
+                            DeserializationContext deserializationcontext) throws IOException, JsonProcessingException {
+
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+        String date = jsonparser.getText();
+        try {
+            return format.parse(date);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+
+}

--- a/src/main/java/com/alienvault/otx/model/pulse/OtxDateDeserializer.java
+++ b/src/main/java/com/alienvault/otx/model/pulse/OtxDateDeserializer.java
@@ -9,18 +9,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-/*
- * © AlienVault Inc. 2017
- * All rights reserved
- * This code is protected by copyright and distributed under licenses
- * restricting its use, copying, distribution, and decompilation. It may
- * only be reproduced or used under license from AlienVault Inc. or its
- * authorised licensees.
- *
- * Created by crosa on 12/07/2017.
-*/
 public class OtxDateDeserializer extends JsonDeserializer<Date> {
-
 
     @Override
     public Date deserialize(JsonParser jsonparser,

--- a/src/main/java/com/alienvault/otx/model/pulse/Pulse.java
+++ b/src/main/java/com/alienvault/otx/model/pulse/Pulse.java
@@ -4,6 +4,7 @@ import com.alienvault.otx.model.indicator.Indicator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -19,7 +20,9 @@ public class Pulse {
     private String description;
     private String author_name;
     private String tlp;
+    @JsonDeserialize(using = OtxDateDeserializer.class)
     private Date modified;
+    @JsonDeserialize(using = OtxDateDeserializer.class)
     private Date created;
     private List<String> tags;
     private List<String> references;


### PR DESCRIPTION
Fix date serialization issue.

Since we were not specifying the date serializer the deserialization made by jackson was wrong:
Using the java sdk I was retrieving a couple of pulses like this:

```
Pulse{name='test2', description='aa', tags=[], indicators=[]}
Created Wed Jul 12 16:39:47 CDT 2017
Modified Wed Jul 12 16:39:47 CDT 2017

Pulse{name='test1', description='', tags=[], indicators=[Indicator{indicator='domain.com', type='DOMAIN', description='lll', created=Wed Jul 12 16:08:32 CDT 2017}]}
Created Wed Jul 12 16:21:49 CDT 2017
Modified Wed Jul 12 16:21:20 CDT 2017
```
And using the python sdk:
```
 {
    "adversary": "",
    "author_name": "cristobal",
    "created": "2017-07-12T21:08:31.798000",
    "description": "",
    "extract_source": [],
    "id": "xxxx",
    "indicators": [
      {
        "content": "",
        "created": "2017-07-12T21:08:32",
        "description": "lll",
        "id": 27276,
        "indicator": "domain.com",
        "title": "kk",
        "type": "domain"
      }
    ],
    "industries": [],
    "modified": "2017-07-12T21:08:48.752000",
    "name": "test1",
    "public": 0,
    "references": [],
    "revision": 2,
    "tags": [],
    "targeted_countries": [],
    "tlp": "white"
  },
 {
    "adversary": "",
    "author_name": "cristobal",
    "created": "2017-07-12T21:25:07.880000",
    "description": "aa",
    "extract_source": [],
    "id": "yyyy",
    "indicators": [],
    "industries": [],
    "modified": "2017-07-12T21:25:07.880000",
    "name": "test2",
    "public": 0,
    "references": [],
    "revision": 1,
    "tags": [],
    "targeted_countries": [],
    "tlp": "white"
  }
```
  
The code I've used to test this is like the following:

```
package com.alienvault.otx;

import com.alienvault.otx.connect.OTXConnection;
import com.alienvault.otx.model.pulse.Pulse;

import java.net.MalformedURLException;
import java.net.URISyntaxException;
import java.util.List;
public class testOtx {
    public static void main(String[] args) throws MalformedURLException, URISyntaxException {
        OTXConnection connection = new OTXConnection("yourapikeyhere");
        List<Pulse> pulseList = connection.getAllPulses();
        for (Pulse pulse : pulseList) {
            System.out.println(pulse.toString());
            System.out.println("Created " + pulse.getCreated().toString());
            System.out.println("Modified "+ pulse.getModified().toString());
            System.out.println("====================================================");
        }
    }
}
```
