### PR TITLE
Add support for missing fields in Pulse model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
 # OTX DirectConnect Java SDK
-OTX DirectConnect provides a mechanism to automatically pull indicators of compromise from the Open Threat Exchange portal into your environment.  The DirectConnect API provides access to all _Pulses_ that you have subscribed to in Open Threat Exchange (https://otx.alienvault.com).
+OTX DirectConnect provides a mechanism to automatically pull indicators of compromise from the Open Threat Exchange portal into your environment.  The DirectConnect API provides access to all _Pulses_ that you have subscribed to in Open Threat Exchange (https://otx.alienvault.com). 
 
 ## Installation and Usage
 1. Clone this repo
 2. Using maven (https://maven.apache.org/) run
 ``` bash
-mvn install
+mvn install -DskipTests
 ```
 3. Then execute the resulting jar file
 ``` bash
 java -jar target/DirectConnect-Java-SDK-0.1.0.jar
+```
+
+## Running the test suite
+1. Edit the file ./src/test/resources/test\_application.properties and add your ATX API key to key= property
+```
+...
+key=<your otx key>
+...
+```
+2. Using maven, run
+``` bash
+mvn install
 ```
 
 ## Commandline Usage

--- a/src/main/java/com/alienvault/otx/model/pulse/Pulse.java
+++ b/src/main/java/com/alienvault/otx/model/pulse/Pulse.java
@@ -19,6 +19,7 @@ public class Pulse {
     private String name;
     private String description;
     private String author_name;
+    private String adversary;
     private String tlp;
     @JsonDeserialize(using = OtxDateDeserializer.class)
     private Date modified;
@@ -26,6 +27,8 @@ public class Pulse {
     private Date created;
     private List<String> tags;
     private List<String> references;
+    private List<String> industries;
+    private List<String> targeted_countries;
     private Integer revision;
     private List<Indicator> indicators;
     private boolean isPublic = true;
@@ -122,6 +125,26 @@ public class Pulse {
     }
 
     /**
+     * Industries associated with this pulse
+     *
+     * @return list of industries
+     */
+    public List<String> getIndustries(){
+        return industries;
+    }
+    public void setIndustries(List<String> industries){
+        this.industries = industries;
+    }
+    /**
+     * Adversary
+     */
+    public String getAdversary(){
+        return adversary;
+    }
+    public void setAdversary(String adversary){
+        this.adversary = adversary;
+    }
+    /**
      * The list of references associated with this pulse
      *
      * @return a list of references
@@ -133,6 +156,8 @@ public class Pulse {
     public void setReferences(List<String> references) {
         this.references = references;
     }
+
+
 
     /**
      * The revision of this representation of the pulse
@@ -187,5 +212,13 @@ public class Pulse {
     @JsonSetter("tlp")
     public void setTlp(String tlp) {
         this.tlp = tlp;
+    }
+    @JsonGetter("targeted_countries")
+    public List<String> getTargetedCountries(){
+        return targeted_countries;
+    }
+    @JsonSetter("targeted_countries")
+    public void setTargetedCountries(List<String> targeted_countries){
+        this.targeted_countries = targeted_countries;
     }
 }


### PR DESCRIPTION
Add the next fields to the Pulse model:

* adversary
* industries
* targeted_countries

Fix the readme with instruction to build without test or to put the OTX API key to 