### PR TITLE
Use DateTimeFormatter to take into account the microseconds

### DIFF
--- a/src/main/java/com/alienvault/otx/model/pulse/OtxDateDeserializer.java
+++ b/src/main/java/com/alienvault/otx/model/pulse/OtxDateDeserializer.java
@@ -6,19 +6,27 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.Date;
 
 public class OtxDateDeserializer extends JsonDeserializer<Date> {
-
+    private static final DateTimeFormatter FORMATTER =
+            new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd'T'HH:mm:ss") // .parseLenient()
+                    .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+                    .toFormatter();
     @Override
     public Date deserialize(JsonParser jsonparser,
                             DeserializationContext deserializationcontext) throws IOException, JsonProcessingException {
 
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
         String date = jsonparser.getText();
+        LocalDateTime localDate = LocalDateTime.parse(date, FORMATTER);
+        Date convertedDatetime = Date.from(localDate.atZone(ZoneId.systemDefault()).toInstant());
         try {
-            return format.parse(date);
+            return convertedDatetime;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Use DateTimeFormatter to take into account microseconds.

NOTE:Requieres JAVA 8